### PR TITLE
Update readme.md

### DIFF
--- a/WinCollect10/Powershell Scripts/AgentInstallation/readme.md
+++ b/WinCollect10/Powershell Scripts/AgentInstallation/readme.md
@@ -11,7 +11,7 @@ This powershell script can be used to install WinCollect 10 on a target endpoint
 The $file parameter is used to specify the path to where the WinCollect 10 agent MSI file is located.
 The $computerName parameter is used to specify the target endpoint where you want to install the agent.
 The WC_DEST parameter is use to specify the QRadar appliance you want to send the events to.
-The ADMIN_GROUP command line parameter must be specified with either a true or false value. A value of true adds the WinCollect virtual account to the Administrators group, whereas a value of false does not.
+The ADMIN_GROUP is required on systems that are not a domain controller.  This command line parameter must be specified with either a true or false value. A value of true adds the WinCollect virtual account to the Administrators group, whereas a value of false does not. This parameter can be omitted when WinCollect 10 is being installed on a domain controller.
 
 ## Author  Team WinCollect
 


### PR DESCRIPTION
Updated readme text to explain that the ADMIN_GROUP parameter can be omitted when WinCollect is being installed on a domain controller.
Signed-off-by: Jay Sartoris <sartoris@ca.ibm.com>